### PR TITLE
Fix stray character and duplicate CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,4 @@
-t<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -37,10 +37,6 @@ t<!DOCTYPE html>
     {{ content }}
 </main>
 
-<link
-  rel="stylesheet"
-  href="{{ '/assets/main.css' | relative_url }}" 
-/>
 <script src="{{ '/assets/js/copy-link.js' | relative_url }}"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- clean up stray `t` at the top of the default layout
- remove duplicate stylesheet link from the body

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*