### PR TITLE
Add Jest setup and tests for copy-link

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,0 +1,21 @@
+name: Node.js Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/cache/
 
 # OS and editor files
 .DS_Store
+node_modules/

--- a/assets/js/copy-link.js
+++ b/assets/js/copy-link.js
@@ -13,3 +13,8 @@ function copyToClipboard(id) {
         alert('Clipboard API not available.');
     }
 }
+
+// Allow importing in Node.js environments for testing
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = copyToClipboard;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "municipal-ordinance-builder",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}

--- a/test/copy-link.test.js
+++ b/test/copy-link.test.js
@@ -1,0 +1,35 @@
+const copyToClipboard = require('../assets/js/copy-link');
+
+describe('copyToClipboard', () => {
+  let writeTextMock;
+
+  beforeEach(() => {
+    // Mock alert to prevent dialogs during tests
+    global.alert = jest.fn();
+
+    // Mock window.location
+    delete window.location;
+    window.location = {
+      origin: 'https://example.com',
+      pathname: '/page'
+    };
+
+    // Mock navigator.clipboard.writeText
+    writeTextMock = jest.fn().mockResolvedValue();
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: { writeText: writeTextMock }
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('writes correct URL to clipboard', async () => {
+    await copyToClipboard('#section');
+    expect(writeTextMock).toHaveBeenCalledWith(
+      'https://example.com/page#section'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Node.js workflow for running `npm test`
- export `copyToClipboard` so tests can import it
- ignore `node_modules`
- add package.json with Jest
- add a test for copy-link.js

## Testing
- `npm test` *(fails: jest not found)*